### PR TITLE
修正：附加timeout参数，在请求超时时，无法触发promise的fail回调

### DIFF
--- a/public/mmRequest.js
+++ b/public/mmRequest.js
@@ -171,6 +171,7 @@ define("mmRequest", ["avalon", "mmPromise"], function(avalon) {
         if (opts.async && opts.timeout > 0) {
             promise.timeoutID = setTimeout(function() {
                 promise.abort("timeout")
+		promise.dispatch(0, "timeout")
             }, opts.timeout)
         }
         promise.request()

--- a/public/mmRequest.modern.js
+++ b/public/mmRequest.modern.js
@@ -150,6 +150,7 @@ define("mmRequest", ["avalon", "mmPromise"], function(avalon) {
         if (opts.async && opts.timeout > 0) {
             promise.timeoutID = setTimeout(function() {
                 promise.abort("timeout")
+		promise.dispatch(0, "timeout")
             }, opts.timeout)
         }
         promise.request()


### PR DESCRIPTION
```
avalon.ready(function() {
        avalon.ajax({
            url: "/basic/search",
            timeout: "2000",
            type: "get",
            dataType: "json",
            cache: false
        }).done(function(data) {
            console.log("done")
        }).fail(function(promise) {
            console.log("fail")
        })
    });
```
